### PR TITLE
Modify PandasSchema so that it's compatible with Dask

### DIFF
--- a/pandas_schema/validation.py
+++ b/pandas_schema/validation.py
@@ -105,11 +105,16 @@ class _SeriesValidation(_BaseValidation):
             validated = simple_validation
 
         # Cut down the original series to only ones that failed the validation
-        indices = series.index[validated]
+        failing = series[validated]
+        # If failing is not of type Series, we assume it's a Dask Series.
+        # compute will convert it into a pandas series.
+        if type(failing) != pd.Series:
+            failing = failing.compute()
+        indices = failing.index
 
         # Use these indices to find the failing items. Also print the index which is probably a row number
         for i in indices:
-            element = series[i]
+            element = failing[i]
             errors.append(ValidationWarning(
                 message=self.message,
                 value=element,


### PR DESCRIPTION
Validation was failing because of a subtle difference in the Dask API compared to pandas. This code segment demonstrates the problem:
```
import pandas as pd
import dask.dataframe as dd

series = dd.from_pandas(pd.Series([1,2,3]), npartitions=1)
mask = dd.from_pandas(pd.Series([True, False, True]), npartitions=1)

# fails with error:
# TypeError: Expected meta to specify type Series, got type pandas.core.indexes.range.RangeIndex
series.index[mask].index
# Okay
series[mask].index
```

These changes work around the issue as well as add a compute step to convert a Dask series of failing row indexes into a Pandas series.

There was another issue that occurred because of a Dask bug where a boolean Dask Series could lose it's dtype after being computed. Looks like the issue is probably in Dask itself, but we can work around it by explicitly setting the type of the Series.